### PR TITLE
Let list elements be any values

### DIFF
--- a/api/v1alpha1/comprehension_types.go
+++ b/api/v1alpha1/comprehension_types.go
@@ -57,8 +57,8 @@ type TemplateExpr struct {
 }
 
 type Generator struct {
-	List  []string     `json:"list,omitempty"` // stand-in for now
-	Query *ObjectQuery `json:"query,omitempty"`
+	List  []apiextensions.JSON `json:"list,omitempty"`
+	Query *ObjectQuery         `json:"query,omitempty"`
 }
 
 type ObjectQuery struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -163,8 +163,10 @@ func (in *Generator) DeepCopyInto(out *Generator) {
 	*out = *in
 	if in.List != nil {
 		in, out := &in.List, &out.List
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = make([]v1.JSON, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Query != nil {
 		in, out := &in.Query, &out.Query

--- a/config/crd/bases/generate.squaremo.dev_comprehensions.yaml
+++ b/config/crd/bases/generate.squaremo.dev_comprehensions.yaml
@@ -46,7 +46,7 @@ spec:
                 properties:
                   list:
                     items:
-                      type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     type: array
                   query:
                     properties:

--- a/controllers/generate_test.go
+++ b/controllers/generate_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 Michael Bridgen.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	generate "github.com/squaremo/comprehension-controller/api/v1alpha1"
+)
+
+func expectGeneratorItems(y string, ev *evaluator, expected []interface{}) {
+	var gen generate.Generator
+	ExpectWithOffset(1, yaml.Unmarshal([]byte(y), &gen)).To(Succeed())
+	e := &env{}
+	objs, err := ev.generateItems(e, &gen)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, objs).To(BeEquivalentTo(expected))
+}
+
+var _ = Describe("generators", func() {
+
+	When("there's a list generator with objects", func() {
+		const generatorYAML = `
+list:
+- foo: bar
+- baz: [1,2,3]
+`
+		It("generates objects", func() {
+			ev := &evaluator{}
+			expectGeneratorItems(generatorYAML, ev, []interface{}{
+				map[string]interface{}{
+					"foo": "bar",
+				},
+				map[string]interface{}{
+					"baz": []interface{}{
+						float64(1), float64(2), float64(3),
+					},
+				},
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
Using `[]string` was a stand-in while I figured out how it should all basically work. But much more useful is to have arbitrary values, then you can e.g., give several parameters at once, like

```
for: obj
in:
  list:
  - name: foo
    labels: {app: foo}
  - name: bar
    labels: {app: bar, layer: base}
```
