### PR TITLE
"When" expressions

### DIFF
--- a/api/v1alpha1/comprehension_types.go
+++ b/api/v1alpha1/comprehension_types.go
@@ -30,6 +30,7 @@ import (
 //
 // forExpr := "var": var
 //            "in": generator
+//            "when": CELexpr
 //
 // var := DNSLABEL
 //
@@ -40,8 +41,9 @@ import (
 // template := k8sTemplate+ /* { TypeMeta... } */
 
 type ForExpr struct {
-	Var string    `json:"var"`
-	In  Generator `json:"in"`
+	Var  string    `json:"var"`
+	In   Generator `json:"in"`
+	When string    `json:"when,omitempty"`
 }
 
 type TemplateExpr struct {

--- a/config/crd/bases/generate.squaremo.dev_comprehensions.yaml
+++ b/config/crd/bases/generate.squaremo.dev_comprehensions.yaml
@@ -63,6 +63,8 @@ spec:
                       type: object
                     var:
                       type: string
+                    when:
+                      type: string
                   required:
                   - in
                   - var

--- a/controllers/eval.go
+++ b/controllers/eval.go
@@ -83,20 +83,19 @@ func (ev *evaluator) evalTop(expr *generate.ComprehensionSpec) ([]interface{}, e
 	if err != nil {
 		return nil, err
 	}
-	return instantiateTemplate(t, map[string]interface{}{}, generatedValues)
+	return instantiateTemplate(t, map[string]interface{}{}, generatedValues, nil)
 }
 
-func instantiateTemplate(t *template, ar map[string]interface{}, rest []generated) ([]interface{}, error) {
+func instantiateTemplate(t *template, ar map[string]interface{}, rest []generated, out []interface{}) ([]interface{}, error) {
 	if len(rest) == 0 {
 		val, err := t.evaluate(ar)
 		if err != nil {
 			return nil, err
 		}
-		return []interface{}{val}, nil
+		return append(out, val), nil
 	}
 
 	g := rest[0]
-	var out []interface{}
 	for i := range g.values {
 		ar[g.name] = g.values[i]
 
@@ -110,11 +109,11 @@ func instantiateTemplate(t *template, ar map[string]interface{}, rest []generate
 			}
 		}
 
-		more, err := instantiateTemplate(t, ar, rest[1:])
+		var err error
+		out, err = instantiateTemplate(t, ar, rest[1:], out)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, more...)
 	}
 	return out, nil
 }

--- a/controllers/eval.go
+++ b/controllers/eval.go
@@ -88,34 +88,14 @@ func (ev *evaluator) evalTop(expr *generate.ComprehensionSpec) ([]interface{}, e
 
 func instantiateTemplate(t *template, ar map[string]interface{}, rest []generated) ([]interface{}, error) {
 	if len(rest) == 0 {
-		return nil, nil
+		val, err := t.evaluate(ar)
+		if err != nil {
+			return nil, err
+		}
+		return []interface{}{val}, nil
 	}
 
 	g := rest[0]
-
-	if len(rest) == 1 {
-		var out []interface{}
-		for i := range g.values {
-			ar[g.name] = g.values[i]
-			if g.when != nil {
-				ref, _, err := g.when.Eval(ar)
-				if err != nil {
-					return nil, err
-				}
-				if !truthy(ref.Value()) {
-					continue
-				}
-			}
-
-			val, err := t.evaluate(ar)
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, val)
-		}
-		return out, nil
-	}
-
 	var out []interface{}
 	for i := range g.values {
 		ar[g.name] = g.values[i]
@@ -125,7 +105,7 @@ func instantiateTemplate(t *template, ar map[string]interface{}, rest []generate
 			if err != nil {
 				return nil, err
 			}
-			if truthy(ref.Value()) {
+			if !truthy(ref.Value()) {
 				continue
 			}
 		}

--- a/controllers/eval_test.go
+++ b/controllers/eval_test.go
@@ -122,3 +122,18 @@ yield:
 	// [a, 2]
 	// [b, 2]
 }
+
+func Example_eval_when() {
+	printEval(`
+yield:
+  template: ${x * x}
+for:
+- var: x
+  in:
+    list: [1,2,3]
+  when: x % 2 == 1
+`)
+	// Output:
+	// 1
+	// 9
+}

--- a/controllers/eval_test.go
+++ b/controllers/eval_test.go
@@ -131,9 +131,32 @@ for:
 - var: x
   in:
     list: [1,2,3]
-  when: x % 2 == 1
+  when: int(x) % 2 == 1
 `)
 	// Output:
 	// 1
 	// 9
+}
+
+func Example_eval_when_nested() {
+	printEval(`
+yield:
+  template: "${a}^2 + ${b}^2 = ${c}^2"
+for:
+- var: "a"
+  in:
+    list: [1,2,3,4,5,6,7,8,9,10]
+- var: "b"
+  in:
+    list: [1,2,3,4,5,6,7,8,9,10]
+- var: "c"
+  in:
+    list: [1,2,3,4,5,6,7,8,9,10]
+  when: c*c == a*a + b*b
+`)
+	// Output:
+	// 3^2 + 4^2 = 5^2
+	// 4^2 + 3^2 = 5^2
+	// 6^2 + 8^2 = 10^2
+	// 8^2 + 6^2 = 10^2
 }


### PR DESCRIPTION
This adds the ability to qualify a generator with a (CEL) "when" expression. The expression is evaluated with each set of bindings, and a value from the generator is only included if the expression doesn't evaluate to `false`. An example is

```yaml
# [ square x | x <- [1,2,3]; odd x ]
yield: ${x} * ${x}
for:
- var x
  in: [1,2,3]
  when: int(x) % 2 == 1
```

This PR simplifies the evaluation a little too.